### PR TITLE
fixing error in config for PayPal Express

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -8,7 +8,7 @@ return array(
 	// Add in each gateway here
 	'gateways' => array(
 		'paypal' => array(
-			'driver' => 'Paypal_Express',
+			'driver' => 'PayPal_Express',
 			'options' => array(
 				'solutionType' => '',
 				'landingPage' => '',


### PR DESCRIPTION
Fix for
Omnipay \ Common \ Exception \ RuntimeException
Class '\Omnipay\Paypal\ExpressGateway' not found
