### PR TITLE
Securely translate underscores into camel case

### DIFF
--- a/src/Ignited/LaravelOmnipay/LaravelOmnipayManager.php
+++ b/src/Ignited/LaravelOmnipay/LaravelOmnipayManager.php
@@ -76,9 +76,11 @@ class LaravelOmnipayManager {
 
         $reflection = new \ReflectionClass($class);
 
+        $toCamelCase = create_function('$c', 'return strtoupper($c[1]);');
+
         foreach($config['options'] as $optionName=>$value)
         {
-            $method = 'set' . ucfirst($optionName);
+            $method = 'set' . preg_replace_callback('/_([a-z])/', $toCamelCase, $optionName);
 
             if ($reflection->hasMethod($method)) {
                 $gateway->{$method}($value);


### PR DESCRIPTION
Gateway `Alipay` adopts underscore naming convention, and requires options like `seller_email` and `return_url`. Using only `ucfirst()` in the reflection function is not adequate, as it translates `seller_email` to `getSeller_email`, rather than `getSellerEmail`. This PR securely translates underscores into camel case.