### PR TITLE
Included options to inject httpClient for omnipay to use Guzzle Plugin

### DIFF
--- a/src/Ignited/LaravelOmnipay/LaravelOmnipayManager.php
+++ b/src/Ignited/LaravelOmnipay/LaravelOmnipayManager.php
@@ -49,19 +49,19 @@ class LaravelOmnipayManager {
      * @param  index of config array to use
      * @return Omnipay\Common\AbstractGateway
      */
-    public function gateway($name = null)
+    public function gateway($name = null, $httpClient = null, $httpRequest = null)
     {
         $name = $name ?: $this->getGateway();
 
         if ( ! isset($this->gateways[$name]))
         {
-            $this->gateways[$name] = $this->resolve($name);
+            $this->gateways[$name] = $this->resolve($name, $httpClient, $httpRequest);
         }
 
         return $this->gateways[$name];
     }
 
-    protected function resolve($name)
+    protected function resolve($name, $httpClient = null, $httpRequest = null)
     {
         $config = $this->getConfig($name);
 
@@ -70,7 +70,7 @@ class LaravelOmnipayManager {
             throw new \UnexpectedValueException("Gateway [$name] is not defined.");
         }
 
-        $gateway = $this->factory->create($config['driver']);
+        $gateway = $this->factory->create($config['driver'], $httpClient, $httpRequest);
 
         $class = trim(Helper::getGatewayClassName($config['driver']), "\\");
 


### PR DESCRIPTION
To unable mock response for tests, we need to inject Guzzle\Plugin\Mock\MockPlugin when creating the gateway like so:

``` php
class ApplicationTest extends TestCase
{

    public function testOmnipayManager()
    {
        // Create gateway using mocked HttpClient
        $this->gateway = \Omnipay::gateway('pagarme', $this->getHttpClient(), $this->getHttpRequest());

        // Add Expected Response from the API
        $this->setMockHttpResponse('AuthorizeCardSuccess.txt');

        $request = $this->gateway->authorize(
            [
                'amount'           => '10.00',
                'soft_descriptor'  => 'test',
            ]
        );

        $response = $request->send();

        $this->assertTrue($response->isSuccessful());
    }
```

More info: http://guzzle3.readthedocs.org/testing/unit-testing.html#queueing-mock-responses

@alexw23 
