### PR TITLE
Updated common/omnipay to v2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Integrates the [Omnipay](https://github.com/adrianmacneil/omnipay) PHP library w
 
 For Laravel 4 see the [version 1.x](https://github.com/ignited/laravel-omnipay/tree/1.1.0) tree
 
-### Now using Omnipay 2.3
+### Now using Omnipay 2.5
  
-Version `2.0` and onwards has been updated to use Omnipay 2.3.
+Version `2.0` and onwards has been updated to use Omnipay 2.5.
 
 ### Composer Configuration
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": ">=5.4.0",
         "illuminate/support": "~5",
-        "omnipay/common": "2.3.*"
+        "omnipay/common": "2.5.*"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
This upgrade is required for Laravel 5 compatibility.  Looking through the change logs it doesn't appear as though there are any breaking changes.
