### PR TITLE
share() method has depreciated in Laravel 5.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.phar
 composer.lock
 .DS_Store
+.idea

--- a/src/Ignited/LaravelOmnipay/BaseServiceProvider.php
+++ b/src/Ignited/LaravelOmnipay/BaseServiceProvider.php
@@ -27,8 +27,7 @@ abstract class BaseServiceProvider extends ServiceProvider {
      */
     public function registerManager()
     {
-        $this->app['omnipay'] = $this->app->share(function($app)
-        {
+        $this->app->singleton('omnipay', function () use ($app) {
             $factory = new GatewayFactory;
             $manager = new LaravelOmnipayManager($app, $factory);
 

--- a/src/Ignited/LaravelOmnipay/BaseServiceProvider.php
+++ b/src/Ignited/LaravelOmnipay/BaseServiceProvider.php
@@ -27,9 +27,9 @@ abstract class BaseServiceProvider extends ServiceProvider {
      */
     public function registerManager()
     {
-        $this->app->singleton('omnipay', function () use ($app) {
+        $this->app->singleton('omnipay', function () {
             $factory = new GatewayFactory;
-            $manager = new LaravelOmnipayManager($app, $factory);
+            $manager = new LaravelOmnipayManager($this->app, $factory);
 
             return $manager;
         });


### PR DESCRIPTION
Use singleton() for service binding as Laravel 5.4 depreciated share() method.