### PR TITLE
Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,8 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "~5|~6|~7",
-        "omnipay/common": "~3.0",
-        "php-http/guzzle6-adapter": "^1.1|^2"
+        "illuminate/support": "~5|~6|~7|~8",
+        "omnipay/common": "~3.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Other than allowing v8 for `illuminate/support`, I also removed `php-http/guzzle6-adapter` since Guzzle 7 which is required for Laravel 8 supports the php-http implementation directly so no need for an adapter (`php-http/guzzle6-adapter` also causes a collision with Guzzle 7). Didn't seem like anything else needed changing.

I'm not sure what the consequences of this are for older versions of Laravel like 5 and 6, so hopefully someone else can look over this before merging. :)